### PR TITLE
If not signed in,  the agate/profile/#(edit/view) page was accessible

### DIFF
--- a/obiba_agate.module
+++ b/obiba_agate.module
@@ -68,6 +68,7 @@ function obiba_agate_menu() {
     'title' => 'User Profile',
     'description' => 'User Profile',
     'page callback' => 'obiba_agate_angular_profile_page',
+    'access callback' => 'obiba_agate_angular_can_edit_profile',
   );
   $items[MicaClientPathProvider::AGATE_REGISTER] = array(
     'access callback' => TRUE,
@@ -109,6 +110,19 @@ function obiba_agate_menu() {
   );
 
   return $items;
+}
+
+/**
+ * Callback to restrict access to agate/profile page by anonymous users.
+ *
+ * @return bool
+ */
+function obiba_agate_angular_can_edit_profile(){
+  global $user;
+  if ($user->uid !=0 ) {
+    return TRUE;
+  }
+  return FALSE;
 }
 
 /**


### PR DESCRIPTION
Must become an access denied if not logged as authenticated user